### PR TITLE
Fix compilation/linking issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,20 @@ hello-world: natives_blob.bin snapshot_blob.bin hello-world.cc
 	clang++ -O0 -g -I$(v8_include_dir) $(v8_dylibs) -L$(v8_build_dir) $@.cc -o $@ -pthread -std=c++0x -rpath $(v8_build_dir)
 
 contexts: natives_blob.bin snapshot_blob.bin contexts.cc
-	clang++ -O0 -g -I$(v8_include_dir) $(v8_dylibs) -L$(v8_build_dir) $@.cc -o $@ -pthread -std=c++0x 
+	clang++ -O0 -g -I$(v8_include_dir) $(v8_dylibs) -L$(v8_build_dir) $@.cc -o $@ -pthread -std=c++0x -rpath $(v8_build_dir)
 
 ns: natives_blob.bin snapshot_blob.bin ns.cc
 	@echo "Using v8_home = $(v8_include_dir)"
-	clang++ -O0 -g -I$(v8_include_dir) $(v8_dylibs) -L$(v8_build_dir) $@.cc -o $@ -pthread -std=c++0x 
+	clang++ -O0 -g -I$(v8_include_dir) $(v8_dylibs) -L$(v8_build_dir) $@.cc -o $@ -pthread -std=c++0x -rpath $(v8_build_dir)
 
 instances: natives_blob.bin snapshot_blob.bin instances.cc
-	clang++ -O0 -g -I$(v8_include_dir) $(v8_dylibs) -L$(v8_build_dir) $@.cc -o $@ -pthread -std=c++0x 
+	clang++ -O0 -g -fno-rtti -I$(v8_include_dir) $(v8_dylibs) -L$(v8_build_dir) $@.cc -o $@ -pthread -std=c++0x -rpath $(v8_build_dir)
 
 run-script: natives_blob.bin snapshot_blob.bin run-script.cc
 	clang++ -O0 -g -I$(v8_include_dir) $(v8_dylibs) -L$(v8_build_dir) $@.cc -o $@ -pthread -std=c++0x -rpath $(v8_build_dir)
 
 exceptions: natives_blob.bin snapshot_blob.bin exceptions.cc
-	clang++ -O0 -g -I$(v8_include_dir) -I$(V8_HOME) $(v8_dylibs) -L$(v8_build_dir) $@.cc $(v8_src_dir)/objects-printer.cc -o $@ -pthread -std=c++0x 
+	clang++ -O0 -g -fno-rtti -I$(v8_include_dir) -I$(V8_HOME) $(v8_dylibs) -L$(v8_build_dir) $@.cc $(v8_src_dir)/objects-printer.cc -o $@ -pthread -std=c++0x -rpath $(v8_build_dir)
 
 natives_blob.bin:
 	@cp $(v8_build_dir)/$@ .


### PR DESCRIPTION
Add rpath to the clang++ call, otherwise the linker does not find the
libraries provided in the builddir, e.g. with

    /usr/bin/ld: warning: libc++.so, needed by /src/v8/v8/out.gn/learning/libv8.so, not found (try using -rpath or -rpath-link)

Disable runtime information with -fno-rtti, otherwise the linker does
not find the typeinfo for the allocator:

    undefined reference to `typeinfo for v8::ArrayBuffer::Allocator'

Background: V8 (and also Node.js) is built without RTTI, but g++ and
clang++ enable them by default. Either V8 has to be build with RTTI
(use_rtti=true) or the own executable without RTTI.