### PR TITLE
fix: cmake gtest-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ gtest-compile: CXXFLAGS = --verbose -Wall -O0 -g -c $(gtest_home)/src/gtest-all.
           -I$(gtest_home)/include
 gtest-compile: 
 	${info Building gtest library}
-	$(CXX) ${CXXFLAGS} $@.cc -o $@
+	$(CXX) ${CXXFLAGS}
 	@mkdir -p $(CURDIR)/lib/gtest
 	${AR} -rv $(CURDIR)/lib/gtest/libgtest.a $(gtest_home)/gtest-all.o
 


### PR DESCRIPTION
There is an error when run `make gtest-compile`.

This PR will fix it.

```
clang: error: no such file or directory: 'gtest-compile.cc'
```